### PR TITLE
fix image upload on iOS

### DIFF
--- a/app/item/items.component.ts
+++ b/app/item/items.component.ts
@@ -105,7 +105,7 @@ export class ItemsComponent implements OnInit {
     }
     uploadMultipartImagePicker(image: Picker.SelectedAsset): Subject<any> {
 
-        let  fileUri = image.fileUri;
+        let  fileUri = image.fileUri.replace("file://","");
 
         let request = {
             url: "http://httpbin.org/post",


### PR DESCRIPTION
don't send the image path as a URL.
Should be

        [{"name":"IMG_0791.JPG","filename":"/var/mobile/Media/DCIM/100APPLE/IMG_0791.JPG","mimeType":"image/jpg"}]

instead of 

        [{"name":"IMG_0791.JPG","filename":"file:///var/mobile/Media/DCIM/100APPLE/IMG_0791.JPG","mimeType":"image/jpg"}]